### PR TITLE
fix: prevent form operations from crashing if property mauticTable is…

### DIFF
--- a/Classes/Transformation/Form/AbstractFormTransformation.php
+++ b/Classes/Transformation/Form/AbstractFormTransformation.php
@@ -200,7 +200,7 @@ abstract class AbstractFormTransformation extends AbstractTransformation impleme
         foreach ($this->customFieldValues as $alias => $properties) {
             foreach ($formElements as $formElement) {
                 if ($formElement['identifier'] === $alias) {
-                    $mauticField = $fieldRepository->getContactFieldByAlias($formElement['properties']['mauticTable']);
+                    $mauticField = $fieldRepository->getContactFieldByAlias($formElement['properties']['mauticTable'] ?? '');
 
                     if (is_array($mauticField) && isset($mauticField['properties'])) {
                         $existingProperties = $mauticField['properties']['list'];


### PR DESCRIPTION
… not defined

relates: https://keibi.toujou.systems/organizations/dfau/issues/1771/?project=3&query=is%3Aunresolved