### PR TITLE
feat: add timestamp to filename due to mautic same file name restriction

### DIFF
--- a/Classes/Service/MauticSendFormService.php
+++ b/Classes/Service/MauticSendFormService.php
@@ -149,10 +149,12 @@ class MauticSendFormService implements SingletonInterface, LoggerAwareInterface
             if (is_array($value)) {
                 $this->addDataToMultipartStreamBuilder($multipartStreamBuilder, $tempPath, $value);
             } elseif ($value instanceof FileReference) {
+                $originalResource = $value->getOriginalResource();
+                $fileName = $originalResource->getNameWithoutExtension() .'_' . time() . '.' .$originalResource->getExtension();
                 $multipartStreamBuilder->addResource(
                     $tempPath,
                     (new StreamFactory())->createStream($value->getOriginalResource()->getContents()),
-                    ['filename' => $value->getOriginalResource()->getName()]
+                    ['filename' => $fileName]
                 );
             } else {
                 $multipartStreamBuilder->addResource($tempPath, (string)$value);


### PR DESCRIPTION
Currently, Mautic allows a maximum of 1,000 submissions with the same filename. Once this limit is exceeded, Mautic returns an "Upload Failed" error. On some devices or browsers, filenames are automatically anonymized, which can lead to reaching this limit unexpectedly and triggering the error.

see https://stackoverflow.com/questions/34920673/ios-file-upload-original-filename#:~:text=Safari%20on%20iOS%20will%20always,trust%20the%20client%20too%20much see https://docs.mautic.org/en/5.2/components/forms.html

relates: https://support.dfau.de/#ticket/zoom/17195