### PR TITLE
fix(form): update FormPersistenceManager::load call for TYPO3 v13

### DIFF
--- a/Classes/Hooks/MauticFormHook.php
+++ b/Classes/Hooks/MauticFormHook.php
@@ -143,7 +143,7 @@ class MauticFormHook implements LoggerAwareInterface
      */
     public function beforeFormDelete(string $formPersistenceIdentifier): string
     {
-        $formDefinition = $this->formPersistenceManager->load($formPersistenceIdentifier);
+        $formDefinition = $this->formPersistenceManager->load($formPersistenceIdentifier, [], []);
 
         if ($this->isResponsible($formDefinition) && isset($formDefinition['renderingOptions']['mauticId'])) {
             $response = $this->formRepository->deleteForm((int)$formDefinition['renderingOptions']['mauticId']);


### PR DESCRIPTION
Adjusts the `beforeFormDelete` method to pass the required `$formSettings` and `$typoScriptSettings` parameters to `FormPersistenceManager::load()`, matching the updated method signature in TYPO3 v13.

relates: https://app.clickup.com/t/36621538/86cadtt99